### PR TITLE
hide last label if it's not 100%

### DIFF
--- a/components/HoneySlider/utlls.ts
+++ b/components/HoneySlider/utlls.ts
@@ -68,10 +68,11 @@ export const getPositionedLabels = ({
 						? {
 								left: 'initial',
 								right: '0',
-								transform: 'initial'
+								transform: 'initial',
+								display: lastLabelValue < 1 ? 'none' : 'initial'
 						  }
 						: {},
-				label: fpr(label)
+				label: fpr(Math.round(label))
 			};
 		}
 	});


### PR DESCRIPTION
in case for example a label for the slider has 60% max allowance but also shows 50% by default, due to the steps of 25%, the 60% label will be hidden to avoid conflicts in the UI.